### PR TITLE
add contract for identity type

### DIFF
--- a/scribblings/github-api.scrbl
+++ b/scribblings/github-api.scrbl
@@ -18,12 +18,12 @@ Before you begin making requests to the GitHub api, you must create an identity.
 @defstruct[github-identity ([type symbol?] [data list?])]{
  This struct holds your GitHub identity.
 
- @racket[type] must be one of the following symbols: @racket['password 'personal-access-token 'oauth]
+ @racket[type] must be one of the following symbols: @racket['password 'personal-token 'oauth]
  
  @racket['password] authentication
  simply uses your GitHub username and password.
 
- @racket['personal-access-token] authentication allows you
+ @racket['personal-token] authentication allows you
  to send your GitHub username and a personal access token (created on your GitHub settings page.)
 
  @racket['oauth] uses an OAuth token for authorization.

--- a/utils.rkt
+++ b/utils.rkt
@@ -4,10 +4,10 @@
  github-api-req/c
  github-api-resp/c
  (contract-out
-  [struct github-identity ([type symbol?] [data (listof string?)])]
+  [struct github-identity ([type github-identity-type/c] [data (listof string?)])]
   [struct github-response ([code number?] [data jsexpr?])]
   [get-status-code (-> string? number?)]
-  [make-auth-header (-> symbol? (listof string?) string?)]
+  [make-auth-header (-> github-identity-type/c (listof string?) string?)]
   [port->jsexpr (-> input-port? jsexpr?)]
   [->string (-> any/c string?)]))
 
@@ -17,6 +17,9 @@
 (struct github-response (code data))
 (define github-api-resp/c github-response?)
 (define github-api-req/c (->* (string?) [#:method string? #:data string? #:media-type string?] github-api-resp/c))
+
+(define github-identity-type/c
+  (or/c 'password 'personal-token 'oauth2))
 
 (module+ test (require rackunit))
 


### PR DESCRIPTION
- fix typo in docs: `personal-access-token` is not a valid identity type
- add a contract for identity types
- use the contract for some util functions

- - -

ps this all started from a contract error:

```
make-auth-header: broke its own contract
  promised: string?
  produced: #<void>
  in: the range of
      (-> symbol? (listof string?) string?)
  contract from: <pkgs>/github-api/utils.rkt
  blaming: <pkgs>/github-api/utils.rkt
   (assuming the contract is correct)
```